### PR TITLE
Add instructions for using Docker Hub images

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,6 @@ Configure which port it binds to with the PORT environment variable.
 
 Build with `go build -o justsayok`
 
-Build the Docker image with `docker build -t justsayok .`
+Build the Docker image with `docker build -t cloudership/justsayok:latest .`
+
+Push to the Cloudership repo on Docker Hub (after logging in) with `docker push cloudership/justsayok:latest`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Configure which port it binds to with the PORT environment variable.
 
 Build with `go build -o justsayok`
 
+Run with `./justsayok` then open http://localhost:3000/ in your browser.
+
+Run the Docker image instead with `docker run --rm -it -p 3000:3000 cloudership/justsayok:latest`
+
 Build the Docker image with `docker build -t cloudership/justsayok:latest .`
 
 Push to the Cloudership repo on Docker Hub (after logging in) with `docker push cloudership/justsayok:latest`


### PR DESCRIPTION
Add instructions for building and pushing to Docker Hub.

Add instructions for running directly from Docker Hub.

Infra support was meant to be added but was decided, for the sake of simplicity and more general distribution and use of the app, to leave it out of this repository.
