### PR TITLE
Document and add support for multi-arch builds with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.20-alpine AS build
+ARG ARCH=
+FROM ${ARCH}golang:1.20-alpine AS build
 
 WORKDIR /app
 
@@ -8,7 +9,7 @@ COPY *.go go.mod ./
 
 RUN go build -o /justsayok
 
-FROM scratch
+FROM ${ARCH}scratch
 
 ENV PORT 3000
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ Run the Docker image instead with `docker run --rm -it -p 3000:3000 cloudership/
 Build the Docker image with `docker build -t cloudership/justsayok:latest .`
 
 Push to the Cloudership repo on Docker Hub (after logging in) with `docker push cloudership/justsayok:latest`
+
+## Multi-Arch Support
+
+To build and push AMD64 and ARM64 architecture images:
+
+```
+docker buildx build --push --platform linux/arm64,linux/amd64 --tag cloudership/justsayok:latest .
+```


### PR DESCRIPTION
Add support for multi-arch builds with Docker.

Specifically, this allows us to push and use ARM64 images in the cloud, which reduces running costs.
